### PR TITLE
Add operations for scalars and integers to the Ed25519 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Bring your own integers to ed25519
+# Ed25519 and Ristretto255 with Injectable BigInt and Hash Dependencies
 
-This is an efficient implementation of [ed25519](https://en.wikipedia.org/wiki/EdDSA) that can be used with any integer arithmetic library that implements a standard interface based on [JSBI](https://github.com/GoogleChromeLabs/jsbi). This allows `pr-ed25519` to be used on platforms where native `bigint`s are not available (e.g. React Native) or with other libraries that may have different performance or security characteristics. The package also allows injection of a SHA-512 dependency, allowing users to
+This is an efficient implementation of [ed25519](https://en.wikipedia.org/wiki/EdDSA) that can be used with any integer arithmetic library that implements a standard interface based on [JSBI](https://github.com/GoogleChromeLabs/jsbi). This allows `ed25519-ts` to be used on platforms where native `bigint`s are not available (e.g. React Native) or with other libraries that may have different performance or security characteristics. The package also allows injection of a SHA-512 dependency, allowing users to
 select native versions when possible and best alternatives when not.
 
 Cryptographic features include:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@privacyresearch/ed25519-ts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "TypeScript implementation of ed25519 & ristretto255 allowing BigInt and SHA dependency injection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@privacyresearch/ed25519-ts",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "TypeScript implementation of ed25519 & ristretto255 allowing BigInt and SHA dependency injection",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__test__/scalars.test.ts
+++ b/src/__test__/scalars.test.ts
@@ -1,0 +1,28 @@
+import { sha512 } from 'js-sha512'
+import JSBI from 'jsbi'
+import { makeED } from '..'
+
+const ed = makeED(JSBI, sha512)
+describe('test scalar operations', () => {
+    test('number serialization', () => {
+        const bigNum = JSBI.multiply(ed.CURVE.P, ed.CURVE.n)
+        const serialized = ed.scalars.serializeNumber(bigNum)
+        const deserialized = ed.scalars.deserializeNumber(serialized)
+
+        expect(serialized.length).toEqual(64)
+        expect(deserialized.toString()).toEqual(bigNum.toString())
+    })
+
+    test('scalar serialization', () => {
+        const bigNum = JSBI.multiply(ed.CURVE.P, ed.CURVE.n)
+        const scalar = JSBI.multiply(ed.CURVE.P, ed.CURVE.n)
+        const serialized = ed.scalars.serializeNumber(bigNum)
+        const serializedScalar = ed.scalars.serializeScalar(scalar)
+        const deserializedScalar1 = ed.scalars.deserializeScalar(serialized)
+        const deserializedScalar2 = ed.scalars.deserializeScalar(serializedScalar)
+
+        expect(serializedScalar.length).toEqual(32)
+        expect(deserializedScalar1.toString()).toEqual('0')
+        expect(deserializedScalar2.toString()).toEqual('0')
+    })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ExtendedPointStatic, makeExtendedPointClass, makePointClass, PointStati
 import { BigIntType, Integers } from './integers'
 import { makeUtils, UtilsType } from './utils'
 import { makeSigningFunctions, SigningFunctions } from './signing'
+import { Scalars } from './scalars'
 
 export * from './integers'
 export * from './native-bigint'
@@ -23,6 +24,8 @@ export interface Ed25519Type<BIT extends BigIntType> extends SigningFunctions<BI
     keyUtils: KeyUtils<BIT>
     CURVE: CurveType<BIT>
     utils: UtilsType
+    Ints: Integers<BIT>
+    scalars: Scalars<BIT>
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -33,6 +36,7 @@ export function makeED<BIT extends BigIntType>(Ints: Integers<BIT>, sha512Impl?:
     const CONSTANTS = makeConstants(toBigInt)
     const math = new MathFunctions(Ints, CURVE, CONSTANTS)
     const keyUtils = new KeyUtils(Ints, CURVE, serializer, math)
+    const scalars = new Scalars(Ints, CURVE, serializer, math)
 
     // Default Point works in default aka affine coordinates: (x, y)
     // Extended Point works in extended coordinates: (x, y, z, t) ∋ (x=x/z, y=y/z, t=xy)
@@ -67,5 +71,7 @@ export function makeED<BIT extends BigIntType>(Ints: Integers<BIT>, sha512Impl?:
         getPublicKey,
         Signature,
         keyUtils,
+        Ints,
+        scalars,
     }
 }

--- a/src/scalars.ts
+++ b/src/scalars.ts
@@ -1,0 +1,33 @@
+import { BigIntType, CurveType, Integers } from '.'
+import { MathFunctions } from './math'
+import { SerializationFunctions } from './serialization'
+
+export class Scalars<BIT extends BigIntType> {
+    private _mod: BIT
+    constructor(
+        private Ints: Integers<BIT>,
+        CURVE: CurveType<BIT>,
+        private _serializer: SerializationFunctions<BIT>,
+        private _math: MathFunctions<BIT>
+    ) {
+        this._mod = CURVE.n
+    }
+
+    serializeScalar(n: BIT): Uint8Array {
+        // First ensure it is reduced modulo the group order
+        const reduced = this._math.mod(n, this._mod)
+        return this._serializer.numberToBytesPadded(reduced, 32)
+    }
+
+    deserializeScalar(buf: Uint8Array): BIT {
+        return this._math.mod(this._serializer.bytesToNumberLE(buf), this._mod)
+    }
+
+    serializeNumber(n: BIT): Uint8Array {
+        const len = Math.ceil((n.toString(16).length - 2) / 2)
+        return this._serializer.numberToBytesPadded(n, len)
+    }
+    deserializeNumber(buf: Uint8Array): BIT {
+        return this._serializer.bytesToNumberLE(buf)
+    }
+}


### PR DESCRIPTION
Users of Ed25519 may need a uniform way to manipulate and (de)serialize the scalars and integers use by the underlying curve implementation.

This PR creates a new object `scalars: Scalars<BIT>` that serializes and deserializes scalars and numbers. It exports this object in the Ed25519 interface.

It also exports the underlying `Integers<BIT>` implementation, allowing users to perform arithmetic directly.